### PR TITLE
fix: do not use title case

### DIFF
--- a/resources/views/components/body/table.blade.php
+++ b/resources/views/components/body/table.blade.php
@@ -59,7 +59,7 @@ border-bottom: 1px solid rgb(210, 210, 210);">
                                     border-top: 1px solid #aaa;
                                     font-weight: bold;
                                 ">
-                            {{ str($column->getLabel())->title() }}</x-filament-reports::table.head-cell>
+                            {{ str($column->getLabel()) }}</x-filament-reports::table.head-cell>
                     @endforeach
                 @endunless
 


### PR DESCRIPTION
In some languages, this results in orthographically wrong titles. A better solution is to define the title with the `title()` function properly.